### PR TITLE
Update default block

### DIFF
--- a/src/blocks/default/index.js
+++ b/src/blocks/default/index.js
@@ -5,23 +5,40 @@
  * It serves as the starting point for new blocks. 😀
  */
 
-//  Import CSS.
-import './style.scss';
-import './editor.scss';
+/**
+ * External dependencies
+ */
+// Import NPM libraries here. Example:
+// import npmPackage from 'npmpackage';
 
+/**
+ * WordPress dependencies
+ */
 const { __ } = wp.i18n; // Import __() from wp.i18n
 const {
 	registerBlockType,
 	Editable,
-} = wp.blocks; // Import registerBlockType() from wp.blocks
+} = wp.blocks; // Import registerBlockType() and Editable() from wp.blocks
 
 /**
- * Register a new block with WordPress.
+ * Internal dependencies
+ */
+import './style.scss';
+import './editor.scss';
+// Import all JS and SCSS files for this block, and any
+// components from the '../../components/' directory.
+
+/**
+ * Register block
  *
  * @link https://wordpress.org/gutenberg/handbook/block-api/
+ * @param  {string}   name     Block name.
+ * @param  {Object}   settings Block settings.
+ * @return {?WPBlock}          The block, if it has been successfully
+ *                             registered; otherwise `undefined`.
  */
 registerBlockType(
-	// Namespaced (wds), hyphens, lowercase, unique name.
+	// Namespaced with 'wds', lowercase, hyphenated. Example: 'wds/example-block-name'
 	'wds/default',
 	{
 		// Localize title using wp.i18n.__()
@@ -30,9 +47,9 @@ registerBlockType(
 		description: __( 'Optional description.' ),
 		// Category options: common, formatting, layout, widgets, embed.
 		category: 'common',
-		// Dashicons options - https://developer.wordpress.org/resource/dashicons/
+		// Can use a Dashicon (see https://developer.wordpress.org/resource/dashicons/) or an imported SVG.
 		icon: 'sos',
-		// Limit to 3 keywords/phrases.
+		// Limit to 3 keywords/phrases. Users will see your block when they search using these keywords.
 		keywords: [
 			__( 'keyword 1' ),
 			__( 'keyword 2' ),
@@ -51,7 +68,7 @@ registerBlockType(
 		// https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/#edit
 		edit: props => {
 			// Event handler to update the value of the content when changed in editor.
-			const onChangeContent = value => {
+			const setContentAttribute = value => {
 				props.setAttributes( { content: value } );
 			};
 			// Return the markup displayed in the editor, including a core Editable field.
@@ -63,13 +80,16 @@ registerBlockType(
 						className="default-block"
 						placeholder={ __( 'Lorem to my Ipsum...' ) }
 						value={ props.attributes.content }
-						onChange={ onChangeContent }
+						onChange={ setContentAttribute }
 					/>
 				</div>
 			);
 		},
 		// Determines what is displayed on the front-end.
 		// https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/#save
+		//
+		// For dynamic blocks, you can return null here and define a render callback function in PHP.
+		// https://wordpress.org/gutenberg/handbook/blocks/creating-dynamic-blocks/
 		save: props => {
 			return (
 				<div className={ props.className }>


### PR DESCRIPTION
Updates:

1. Group dependencies as external/wordpress/internal like the core Gutenberg plugin does
2. Add docBlock
3. Set onChange event handler function to reflect what it does rather than when it's called
4. Add additional details to inline comments