### PR TITLE
Hotfix/content blocks with sidebar

### DIFF
--- a/dist/blocks.editor.build.css
+++ b/dist/blocks.editor.build.css
@@ -1,13 +1,696 @@
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wds-block-title{background-color:transparent}.content-block-header h2{margin-bottom:0}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wds-background-options .blocks-base-control{width:100%}.wds-background-options .components-button svg{position:relative;top:5px}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wds-other-options .blocks-base-control{width:100%}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.editor-block-list__layout .button.wds-button-component{background-color:transparent;border:none;-webkit-box-shadow:none;box-shadow:none;height:unset;max-width:280px;padding:0}.editor-block-list__layout .button.wds-button-component textarea{border-radius:0;padding:5px 10px}.editor-block-list__layout .button.wds-button-component form{padding:0 10px;border-radius:0}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.gist-block-controls{padding:2px}.gist-block-controls input[type="url"]{min-width:300px}@media (min-width: 600px){.gist-block-controls input[type="url"]{min-width:350px}}.gist-block-controls .button{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.edit-post-visual-editor .editor-block-list__block .wp-block-wds-hero{min-height:320px}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.search-container-list{border:1px solid #dedede;display:-ms-flexbox;display:flex;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;position:relative}.search-container-list .search-left-column,.search-container-list .search-right-column{height:19rem;margin:0;width:50%}.search-container-list .search-left-column h3,.search-container-list .search-right-column h3{background-color:#f8f9f9;border-bottom:1px solid #dedede;-ms-flex:0 0 50%;flex:0 0 50%;margin:0;padding:0.4375rem;text-transform:capitalize}.search-container-list .search-left-column>ul,.search-container-list .search-right-column>ul{height:calc(100% - 52px);margin:0;overflow-y:auto}.search-container-list .search-left-column>ul li,.search-container-list .search-right-column>ul li{border-bottom:1px solid #dedede;cursor:pointer;font-size:1rem;line-height:1.125rem;list-style:none;padding:0.4375rem}.search-container-list .search-left-column>ul li:last-child,.search-container-list .search-right-column>ul li:last-child{border-bottom:0}.search-container-list .search-left-column a,.search-container-list .search-right-column a{color:inherit}.search-container-list .search-left-column{border-right:1px solid #dedede}.search-container-list .search-left-column>ul li.is-selected{cursor:default;opacity:0.5;pointer-events:none}.search-container-list .search-selected-container{min-height:19rem}.search-container-list .wp-block-loader{background-color:rgba(248,249,249,0.8);height:100%;position:absolute;width:100%}.search-container-list .wp-block-loader>img{left:50%;position:absolute;top:50%;-webkit-transform:translateX(-50%);-ms-transform:translateX(-50%);transform:translateX(-50%)}.search-container-list .selected-users-container{display:-ms-flexbox;display:flex;-ms-flex-pack:space-evenly;justify-content:space-evenly;width:100%}.search-container-list .selected-users-container:not(.wp-block-gallery){list-style-type:none}.search-container-list .selected-users-container li{text-align:center}.search-container-list .selected-users-container li img{border-radius:100%}.editor-block-list__block input.wds-search-form{border-radius:0;font-size:1rem;margin:0 0 -0.0625rem;padding:0.625rem;position:relative;width:100%;z-index:100}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wp-block-wds-two-column .content-block-container .components-button svg{position:relative;top:5px}.wp-block-wds-two-column .block-title{background-color:transparent}.wp-admin .wp-block-wds-two-column .content-block-content h2{color:#b1b1b1;font-size:17px}div[data-type='wds/two-column'] .editor-block-contextual-toolbar{height:auto}div[data-type='wds/two-column'] .editor-block-toolbar{background-color:#fff;display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;margin-top:20px;position:relative;width:100%}div[data-type='wds/two-column'] .editor-block-toolbar>div{-ms-flex-pack:justify;justify-content:space-between}div[data-type='wds/two-column'] .editor-block-toolbar>div:first-child{border-bottom:1px solid #e2e4e7}.wds-two-column-options .blocks-base-control{width:100%}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wp-block-wds-recent-posts ul li{list-style:none}.wp-block-wds-recent-posts ul.columns-2 li{width:calc( ( 100% / 2 ) - 16px)}.wp-block-wds-recent-posts ul.columns-3 li{width:calc( ( 100% / 3 ) - 16px)}.wp-block-wds-recent-posts ul.columns-4 li{width:calc( ( 100% / 4 ) - 16px)}.wp-block-wds-recent-posts ul.columns-5 li{width:calc( ( 100% / 5 ) - 16px)}.wp-block-wds-recent-posts ul.columns-6 li{width:calc( ( 100% / 6 ) - 16px)}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.multiselect-wrapper{border:1px solid #dedede;border-bottom:0;border-radius:4px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;position:relative}.select-dropdown{border-top:0;display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;left:0;overflow:hidden;position:relative;top:0;width:100%;z-index:1}.select-dropdown label{background-color:#f8f9f9;border-bottom:1px solid #dedede;padding:0.3125rem 0.625rem}.select-dropdown input[type='checkbox']{left:-9999px;position:absolute;top:-9999px}.select-dropdown input[type='checkbox']:focus+label{background-color:#b1b1b1}.select-dropdown input[type='checkbox']:checked:focus+label{background-color:#b1b1b1}.select-dropdown input[type='checkbox']:checked+label{background-color:#dedede}.select-dropdown.hidden{height:0}.select-dropdown.shown{overflow:auto}.select-input{padding:0.625rem}.select-input .item-pill{background-color:#f8f9f9;border-radius:3px;border:1px solid #dedede;display:inline-block;margin-right:5px;padding:0 5px;position:relative}.select-input .item-pill::after{color:#dedede;content:'\00d7';margin-left:5px}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wds-block-title {
+  background-color: transparent; }
+
+.content-block-header h2 {
+  margin-bottom: 0; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wds-background-options .blocks-base-control {
+  width: 100%; }
+
+.wds-background-options .components-button svg {
+  position: relative;
+  top: 5px; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wds-other-options .blocks-base-control {
+  width: 100%; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.editor-block-list__layout .button.wds-button-component {
+  background-color: transparent;
+  border: none;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  height: unset;
+  max-width: 280px;
+  padding: 0; }
+  .editor-block-list__layout .button.wds-button-component textarea {
+    border-radius: 0;
+    padding: 5px 10px; }
+  .editor-block-list__layout .button.wds-button-component form {
+    padding: 0 10px;
+    border-radius: 0; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.gist-block-controls {
+  padding: 2px; }
+  .gist-block-controls input[type="url"] {
+    min-width: 300px; }
+    @media (min-width: 600px) {
+      .gist-block-controls input[type="url"] {
+        min-width: 350px; } }
+  .gist-block-controls .button {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.edit-post-visual-editor .editor-block-list__block .wp-block-wds-hero {
+  min-height: 320px; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.search-container-list {
+  border: 1px solid #dedede;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  position: relative; }
+  .search-container-list .search-left-column,
+  .search-container-list .search-right-column {
+    height: 19rem;
+    margin: 0;
+    width: 50%; }
+    .search-container-list .search-left-column h3,
+    .search-container-list .search-right-column h3 {
+      background-color: #f8f9f9;
+      border-bottom: 1px solid #dedede;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
+      margin: 0;
+      padding: 0.4375rem;
+      text-transform: capitalize; }
+    .search-container-list .search-left-column > ul,
+    .search-container-list .search-right-column > ul {
+      height: calc(100% - 52px);
+      margin: 0;
+      overflow-y: auto; }
+      .search-container-list .search-left-column > ul li,
+      .search-container-list .search-right-column > ul li {
+        border-bottom: 1px solid #dedede;
+        cursor: pointer;
+        font-size: 1rem;
+        line-height: 1.125rem;
+        list-style: none;
+        padding: 0.4375rem; }
+        .search-container-list .search-left-column > ul li:last-child,
+        .search-container-list .search-right-column > ul li:last-child {
+          border-bottom: 0; }
+    .search-container-list .search-left-column a,
+    .search-container-list .search-right-column a {
+      color: inherit; }
+  .search-container-list .search-left-column {
+    border-right: 1px solid #dedede; }
+    .search-container-list .search-left-column > ul li.is-selected {
+      cursor: default;
+      opacity: 0.5;
+      pointer-events: none; }
+  .search-container-list .search-selected-container {
+    min-height: 19rem; }
+  .search-container-list .wp-block-loader {
+    background-color: rgba(248, 249, 249, 0.8);
+    height: 100%;
+    position: absolute;
+    width: 100%; }
+    .search-container-list .wp-block-loader > img {
+      left: 50%;
+      position: absolute;
+      top: 50%;
+      -webkit-transform: translateX(-50%);
+          -ms-transform: translateX(-50%);
+              transform: translateX(-50%); }
+  .search-container-list .selected-users-container {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-pack: space-evenly;
+        justify-content: space-evenly;
+    width: 100%; }
+    .search-container-list .selected-users-container:not(.wp-block-gallery) {
+      list-style-type: none; }
+    .search-container-list .selected-users-container li {
+      text-align: center; }
+      .search-container-list .selected-users-container li img {
+        border-radius: 100%; }
+
+.editor-block-list__block input.wds-search-form {
+  border-radius: 0;
+  font-size: 1rem;
+  margin: 0 0 -0.0625rem;
+  padding: 0.625rem;
+  position: relative;
+  width: 100%;
+  z-index: 100; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wp-block-wds-two-column .content-block-container .components-button svg {
+  position: relative;
+  top: 5px; }
+
+.wp-block-wds-two-column .block-title {
+  background-color: transparent; }
+
+.wp-admin .wp-block-wds-two-column .content-block-content h2 {
+  color: #b1b1b1;
+  font-size: 17px; }
+
+div[data-type='wds/two-column'] .editor-block-contextual-toolbar {
+  height: auto; }
+
+div[data-type='wds/two-column'] .editor-block-toolbar {
+  background-color: #fff;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  margin-top: 20px;
+  position: relative;
+  width: 100%; }
+  div[data-type='wds/two-column'] .editor-block-toolbar > div {
+    -ms-flex-pack: justify;
+        justify-content: space-between; }
+    div[data-type='wds/two-column'] .editor-block-toolbar > div:first-child {
+      border-bottom: 1px solid #e2e4e7; }
+
+.wds-two-column-options .blocks-base-control {
+  width: 100%; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wp-block-wds-recent-posts ul li {
+  list-style: none; }
+
+.wp-block-wds-recent-posts ul.columns-2 li {
+  width: calc( ( 100% / 2 ) - 16px); }
+
+.wp-block-wds-recent-posts ul.columns-3 li {
+  width: calc( ( 100% / 3 ) - 16px); }
+
+.wp-block-wds-recent-posts ul.columns-4 li {
+  width: calc( ( 100% / 4 ) - 16px); }
+
+.wp-block-wds-recent-posts ul.columns-5 li {
+  width: calc( ( 100% / 5 ) - 16px); }
+
+.wp-block-wds-recent-posts ul.columns-6 li {
+  width: calc( ( 100% / 6 ) - 16px); }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.multiselect-wrapper {
+  border: 1px solid #dedede;
+  border-bottom: 0;
+  border-radius: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  position: relative; }
+
+.select-dropdown {
+  border-top: 0;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  left: 0;
+  overflow: hidden;
+  position: relative;
+  top: 0;
+  width: 100%;
+  z-index: 1; }
+  .select-dropdown label {
+    background-color: #f8f9f9;
+    border-bottom: 1px solid #dedede;
+    padding: 0.3125rem 0.625rem; }
+  .select-dropdown input[type='checkbox'] {
+    left: -9999px;
+    position: absolute;
+    top: -9999px; }
+    .select-dropdown input[type='checkbox']:focus + label {
+      background-color: #b1b1b1; }
+    .select-dropdown input[type='checkbox']:checked:focus + label {
+      background-color: #b1b1b1; }
+    .select-dropdown input[type='checkbox']:checked + label {
+      background-color: #dedede; }
+  .select-dropdown.hidden {
+    height: 0; }
+  .select-dropdown.shown {
+    overflow: auto; }
+
+.select-input {
+  padding: 0.625rem; }
+  .select-input .item-pill {
+    background-color: #f8f9f9;
+    border-radius: 3px;
+    border: 1px solid #dedede;
+    display: inline-block;
+    margin-right: 5px;
+    padding: 0 5px;
+    position: relative; }
+    .select-input .item-pill::after {
+      color: #dedede;
+      content: '\00d7';
+      margin-left: 5px; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }

--- a/dist/blocks.style.build.css
+++ b/dist/blocks.style.build.css
@@ -1,8 +1,452 @@
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wds-components-placeholder{display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center;padding:1em;min-height:200px;text-align:center;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;font-size:13px;background:#f8f9f9}.wds-components-placeholder__label{display:-ms-flexbox;display:flex;-ms-flex-pack:center;justify-content:center;font-weight:bold;margin-bottom:1em}.wds-components-placeholder__label .icon{margin-right:1ch}.wds-components-placeholder__fieldset,.wds-components-placeholder__fieldset form{display:-ms-flexbox;display:flex;-ms-flex-direction:row;flex-direction:row;-ms-flex-pack:center;justify-content:center;width:100%;max-width:280px;-ms-flex-wrap:wrap;flex-wrap:wrap}.wds-components-placeholder__fieldset p,.wds-components-placeholder__fieldset form p{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;font-size:13px}.wds-components-placeholder__input{margin-right:8px;-ms-flex:1 1 auto;flex:1 1 auto}.wds-components-placeholder__instructions{margin-bottom:1em}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wp-block-wds-gihub-gist{margin-top:16px}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wp-block-wds-hero{background-repeat:no-repeat;background-size:cover;display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column;-ms-flex-pack:center;justify-content:center;min-height:640px}.site-content .wp-block-wds-hero{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wds-search-component-container .search-container-list>.search-selected-container{padding:0.625rem 0.625rem 0}.wds-search-component-container .search-selected-container{display:-ms-flexbox;display:flex;-ms-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0;padding:0;width:100%}.wds-search-component-container .search-selected-container li{-ms-flex:0 0 31.333%;flex:0 0 31.333%;list-style:none;margin-bottom:1.5625rem;margin-right:3%}.wds-search-component-container .search-selected-container li:nth-child(3n){margin-right:0}.wds-search-component-container .search-selected-container li h3{line-height:1.125;margin-top:0}.wds-search-component-container .search-selected-container li p{font-size:0.875rem;line-height:1.5;margin-bottom:0}.wds-search-component-container .search-selected-container li a{color:inherit}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wp-block-wds-two-column .content-block-container{display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column}@media (min-width: 600px){.wp-block-wds-two-column .content-block-container{-ms-flex-direction:row;flex-direction:row}}.wp-block-wds-two-column .content-block-content{-ms-flex:1 1 100%;flex:1 1 100%}@media (min-width: 600px){.wp-block-wds-two-column .content-block-content{-ms-flex:0 1 50%;flex:0 1 50%;max-width:50%}}@media (min-width: 600px){.wp-block-wds-two-column .content-block-content:last-child{margin-left:20px}}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}.wp-block-wds-recent-posts ul.alignleft{margin-right:2em}.wp-block-wds-recent-posts ul.aligncenter{text-align:center}.wp-block-wds-recent-posts ul.alignright{margin-left:2em}.wp-block-wds-recent-posts ul.is-grid{display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;list-style:none;padding:0}.wp-block-wds-recent-posts ul.is-grid li{margin:0 16px 16px 0;width:100%}.wp-block-wds-recent-posts ul.columns-2 li{width:calc( ( 100% / 2 ) - 16px)}.wp-block-wds-recent-posts ul.columns-3 li{width:calc( ( 100% / 3 ) - 16px)}.wp-block-wds-recent-posts ul.columns-4 li{width:calc( ( 100% / 4 ) - 16px)}.wp-block-wds-recent-posts ul.columns-5 li{width:calc( ( 100% / 5 ) - 16px)}.wp-block-wds-recent-posts ul.columns-6 li{width:calc( ( 100% / 6 ) - 16px)}
-.wp-admin [data-type^="wds"]{margin-bottom:30px;margin-top:30px;max-width:none}.has-video-background{overflow:hidden;position:relative}.has-video-background .video-container{height:100%;left:50%;min-height:100%;min-width:100%;-o-object-fit:none;object-fit:none;-o-object-position:center center;object-position:center center;position:absolute;-webkit-transform:translate(-50%, -50%);-ms-transform:translate(-50%, -50%);transform:translate(-50%, -50%);top:50%;width:100%;z-index:-1}.has-custom-background{background-position:center center;background-repeat:no-repeat;padding:20px}.site-content .has-custom-background{left:50%;margin-left:-50vw;margin-right:-50vw;position:relative;right:50%;width:100vw}
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wds-components-placeholder {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  -ms-flex-align: center;
+      align-items: center;
+  -ms-flex-pack: center;
+      justify-content: center;
+  padding: 1em;
+  min-height: 200px;
+  text-align: center;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 13px;
+  background: #f8f9f9; }
+
+.wds-components-placeholder__label {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: center;
+      justify-content: center;
+  font-weight: bold;
+  margin-bottom: 1em; }
+  .wds-components-placeholder__label .icon {
+    margin-right: 1ch; }
+
+.wds-components-placeholder__fieldset,
+.wds-components-placeholder__fieldset form {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: row;
+      flex-direction: row;
+  -ms-flex-pack: center;
+      justify-content: center;
+  width: 100%;
+  max-width: 280px;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap; }
+  .wds-components-placeholder__fieldset p,
+  .wds-components-placeholder__fieldset form p {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    font-size: 13px; }
+
+.wds-components-placeholder__input {
+  margin-right: 8px;
+  -ms-flex: 1 1 auto;
+      flex: 1 1 auto; }
+
+.wds-components-placeholder__instructions {
+  margin-bottom: 1em; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wp-block-wds-gihub-gist {
+  margin-top: 16px; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wp-block-wds-hero {
+  background-repeat: no-repeat;
+  background-size: cover;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column;
+  -ms-flex-pack: center;
+      justify-content: center;
+  min-height: 640px; }
+  body:not(.has-sidebar) .site-content .wp-block-wds-hero {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wds-search-component-container .search-container-list > .search-selected-container {
+  padding: 0.625rem 0.625rem 0; }
+
+.wds-search-component-container .search-selected-container {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-flow: row wrap;
+      flex-flow: row wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%; }
+  .wds-search-component-container .search-selected-container li {
+    -ms-flex: 0 0 31.333%;
+        flex: 0 0 31.333%;
+    list-style: none;
+    margin-bottom: 1.5625rem;
+    margin-right: 3%; }
+    .wds-search-component-container .search-selected-container li:nth-child(3n) {
+      margin-right: 0; }
+    .wds-search-component-container .search-selected-container li h3 {
+      line-height: 1.125;
+      margin-top: 0; }
+    .wds-search-component-container .search-selected-container li p {
+      font-size: 0.875rem;
+      line-height: 1.5;
+      margin-bottom: 0; }
+    .wds-search-component-container .search-selected-container li a {
+      color: inherit; }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-wds-two-column .content-block-container {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column;
+      flex-direction: column; }
+  @media (min-width: 600px) {
+    .wp-block-wds-two-column .content-block-container {
+      -ms-flex-direction: row;
+          flex-direction: row; } }
+
+.wp-block-wds-two-column .content-block-content {
+  -ms-flex: 1 1 100%;
+      flex: 1 1 100%; }
+  @media (min-width: 600px) {
+    .wp-block-wds-two-column .content-block-content {
+      -ms-flex: 0 1 50%;
+          flex: 0 1 50%;
+      max-width: 50%; } }
+  @media (min-width: 600px) {
+    .wp-block-wds-two-column .content-block-content:last-child {
+      margin-left: 20px; } }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }
+
+.wp-block-wds-recent-posts ul.alignleft {
+  margin-right: 2em; }
+
+.wp-block-wds-recent-posts ul.aligncenter {
+  text-align: center; }
+
+.wp-block-wds-recent-posts ul.alignright {
+  margin-left: 2em; }
+
+.wp-block-wds-recent-posts ul.is-grid {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  list-style: none;
+  padding: 0; }
+  .wp-block-wds-recent-posts ul.is-grid li {
+    margin: 0 16px 16px 0;
+    width: 100%; }
+
+.wp-block-wds-recent-posts ul.columns-2 li {
+  width: calc( ( 100% / 2 ) - 16px); }
+
+.wp-block-wds-recent-posts ul.columns-3 li {
+  width: calc( ( 100% / 3 ) - 16px); }
+
+.wp-block-wds-recent-posts ul.columns-4 li {
+  width: calc( ( 100% / 4 ) - 16px); }
+
+.wp-block-wds-recent-posts ul.columns-5 li {
+  width: calc( ( 100% / 5 ) - 16px); }
+
+.wp-block-wds-recent-posts ul.columns-6 li {
+  width: calc( ( 100% / 6 ) - 16px); }
+.wp-admin [data-type^="wds"] {
+  margin-bottom: 30px;
+  margin-top: 30px;
+  max-width: none; }
+
+.has-video-background {
+  overflow: hidden;
+  position: relative; }
+  .has-video-background .video-container {
+    height: 100%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -o-object-fit: none;
+       object-fit: none;
+    -o-object-position: center center;
+       object-position: center center;
+    position: absolute;
+    -webkit-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    top: 50%;
+    width: 100%;
+    z-index: -1; }
+
+.has-custom-background {
+  background-position: center center;
+  background-repeat: no-repeat;
+  padding: 20px; }
+  body:not(.has-sidebar) .site-content .has-custom-background {
+    left: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    position: relative;
+    right: 50%;
+    width: 100vw; }

--- a/src/blocks/hero/style.scss
+++ b/src/blocks/hero/style.scss
@@ -14,6 +14,10 @@
 
 	// The should help the front end only to work out of the box.
 	.site-content & {
-		@include full-width;
+
+		// Don't apply full-width styles if we have a sidebar.
+		body:not(.has-sidebar) & {
+			@include full-width;
+		} // body:not(.has-sidebar) &
 	} // .site-content &
 } // .wp-block-wds-hero

--- a/src/sass/_global-blocks.scss
+++ b/src/sass/_global-blocks.scss
@@ -38,6 +38,10 @@
 
 	// The should help the front end only to work out of the box.
 	.site-content & {
-		@include full-width;
+
+		// Don't apply full-width styles if we have a sidebar.
+		body:not(.has-sidebar) & {
+			@include full-width;
+		} // body:not(.has-sidebar) &
 	} // .site-content &
 } // .has-custom-background


### PR DESCRIPTION
Closes https://github.com/WebDevStudios/wd_s/issues/367

### DESCRIPTION ###
@gregrickaby and I discovered that using full-width blocks would break the layout when used on a page/post with a sidebar.  We logged it as a bug in wd_s, but in digging in it does appear that the issue lies in the plugin's base styles for layout.  I'm not sure if these styles could necessarily be moved out of the plugin since they're not really opinionated and are just enough to get the layout working.

This looks for our `has-sidebar` class (used in wd_s) and doesn't apply full-width styles on blocks where that body class is found.

### SCREENSHOTS ###
![](https://dl.dropbox.com/s/y2hskhmc4g502dj/Screenshot%202018-05-01%2013.32.00.jpg?dl=0)
![](https://dl.dropbox.com/s/yaho03pcqbmce3b/Screenshot%202018-05-01%2013.32.16.jpg?dl=0)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass linting? (ESLint)

### STEPS TO VERIFY ###
Add blocks to a post and give them a background image, color, or video. They should now stay within the content area rather than breaking like we were seeing in the wd_s issue noted above.
