### PR TITLE
Add in all dependencies when enqueueing scripts 

### DIFF
--- a/src/init.php
+++ b/src/init.php
@@ -42,7 +42,7 @@ function enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'wds-blocks-editor-js',
 		plugins_url( 'dist/blocks.build.js', __DIR__ ),
-		[ 'wp-blocks', 'wp-i18n', 'wp-element' ], // Dependencies, defined above.
+		[ 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-editor' ], // Dependencies, defined above.
 		filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' )
 	);
 


### PR DESCRIPTION
Add in `wp-components` and `wp-editor` to the dependency list, which helps when working on WP5.0 Bleeding edge

Closes #__

### DESCRIPTION ###
In WP 5.0 Gutenberg does not automatically enqueue components and editor into the mix. There for you get an error along the lines of `Cannot get "PlainText" from undefined`


### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass linting? (ESLint)

### STEPS TO VERIFY ###
How do we test this? 
Activate plugin whilst using WP Beta Tester plugin.

### DOCUMENTATION ###
Will this pull request require updating the WDS Blocks [wiki](https://github.com/WebDevStudios/wds-blocks/wiki)?
Nope