### PR TITLE
Add component and hook to handle toggling edit/preview modes

### DIFF
--- a/src/utils/preview-toggle/PreviewToggle.js
+++ b/src/utils/preview-toggle/PreviewToggle.js
@@ -11,10 +11,7 @@ import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
  * @return {WPElement}      Element to render.
  */
 export default function PreviewToggle( props ) {
-	const {
-		showPreview = true,
-		togglePreview,
-	} = props;
+	const { showPreview = true, togglePreview } = props;
 
 	return (
 		<BlockControls>

--- a/src/utils/preview-toggle/PreviewToggle.js
+++ b/src/utils/preview-toggle/PreviewToggle.js
@@ -1,0 +1,38 @@
+import { BlockControls } from '@wordpress/block-editor';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+
+/**
+ * The PreviewToggle component displays a toolbar button to toggle between "edit" and "preview" block modes.
+ *
+ * @author WebDevStudios
+ * @since  2.0.0
+ *
+ * @param  {Object} [props] Properties passed to the component.
+ * @return {WPElement}      Element to render.
+ */
+export default function PreviewToggle( props ) {
+	const {
+		showPreview = true,
+		togglePreview,
+	} = props;
+
+	return (
+		<BlockControls>
+			<ToolbarGroup>
+				{ showPreview ? (
+					<ToolbarButton
+						icon="edit"
+						label="Switch to Edit"
+						onClick={ () => togglePreview() }
+					/>
+				) : (
+					<ToolbarButton
+						icon="welcome-view-site"
+						label="Switch to Preview"
+						onClick={ () => togglePreview() }
+					/>
+				) }
+			</ToolbarGroup>
+		</BlockControls>
+	);
+}

--- a/src/utils/preview-toggle/usePreviewToggle.js
+++ b/src/utils/preview-toggle/usePreviewToggle.js
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+/**
+ * The usePreviewToggle hook handles state for toggling between "edit" and "preview" modes.
+ *
+ * @author WebDevStudios
+ * @since  2.0.0
+ *
+ * @return {Object} Object consisting of state variable and state toggle function.
+ */
+export default function usePreviewToggle() {
+	const [ showPreview, setPreview ] = useState( true );
+
+	/**
+	 * Toggle between "edit" and "preview" modes by setting `showPreview` to the boolean inverse of its current value.
+	 *
+	 * @author WebDevStudios
+	 * @since  2.0.0
+	 */
+	const togglePreview = () => {
+		setPreview( ! showPreview );
+	};
+
+	return {
+		showPreview,
+		togglePreview,
+	};
+}


### PR DESCRIPTION
### DESCRIPTION ###

- Creates `PreviewToggle` component, which displays a toolbar button to toggle between edit and preview modes.
- Creates `usePreviewToggle` hook, which sets up the toggle state vars/functions for use with the custom component.

### SCREENSHOTS ###

In Preview mode:
![Screen Shot 2020-08-25 at 4 20 41 PM](https://user-images.githubusercontent.com/36422618/91233668-f24da080-e6ee-11ea-83f2-c0b2f702bd7f.png)

In Edit mode:
![Screen Shot 2020-08-25 at 4 19 49 PM](https://user-images.githubusercontent.com/36422618/91233675-f5489100-e6ee-11ea-850e-65938de30a78.png)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass linting? (ESLint)

### STEPS TO VERIFY ###

Include hook and component in `Edit` function of a custom block, e.g.:
```
const { showPreview, togglePreview } = usePreviewToggle();
...
return (
    ...
    <PreviewToggle
        showPreview={ showPreview }
	togglePreview={ togglePreview }
    />
    ...
);
```

In the admin, select block and use the new toolbar button to toggle between edit/preview modes.

Note: this works with the [/feature/global-block-styles](https://github.com/WebDevStudios/WDS-Blocks/tree/feature/global-block-styles) branch to apply the edit mode styling provided by that branch. To combine, add the following code in addition to the code outlined in both PRs, in the block's `Edit` function's return:
```
<div className={ `${ className } ${ showPreview ? 'preview-mode' : 'edit-mode' }` }>
```

### DOCUMENTATION ###
Will this pull request require updating the WDS Blocks [wiki](https://github.com/WebDevStudios/wds-blocks/wiki)?
Most likely, as this is meant to be used across nested custom blocks.
