### PR TITLE
Adding block category from wd_s acf starter into WDS-Blocks plugin

### DIFF
--- a/wds-blocks.php
+++ b/wds-blocks.php
@@ -108,7 +108,7 @@ function register_block_category( $categories, $post ) {
 		array(
 			array(
 				'slug'  => 'wds-blocks',
-				'title' => __( 'WDS Blocks', 'wdsblocks' ),
+				'title' => esc_html__( 'WDS Blocks', 'wdsblocks' ),
 			),
 		)
 	);

--- a/wds-blocks.php
+++ b/wds-blocks.php
@@ -90,3 +90,26 @@ function register_block() {
 	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Adds a WDS Block category to the Gutenberg category list.
+ *
+ * @param array  $categories The existing categories.
+ * @param object $post The current post.
+ * @return array The updated array of categories.
+ * @author WebDevStudios
+ * @since 2.0.0
+ */
+function register_block_category( $categories, $post ) {
+
+	return array_merge(
+		$categories,
+		array(
+			array(
+				'slug'  => 'wds-blocks',
+				'title' => esc_html__( 'WDS Blocks', 'wdsblocks' ),
+			),
+		)
+	);
+}
+add_filter( 'block_categories', __NAMESPACE__ . '\register_block_category', 10, 2 );

--- a/wds-blocks.php
+++ b/wds-blocks.php
@@ -94,11 +94,12 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 /**
  * Adds a WDS Block category to the Gutenberg category list.
  *
+ * @author WebDevStudios
+ * @since 2.0.0
+ *
  * @param array  $categories The existing categories.
  * @param object $post The current post.
  * @return array The updated array of categories.
- * @author WebDevStudios
- * @since 2.0.0
  */
 function register_block_category( $categories, $post ) {
 
@@ -107,7 +108,7 @@ function register_block_category( $categories, $post ) {
 		array(
 			array(
 				'slug'  => 'wds-blocks',
-				'title' => esc_html__( 'WDS Blocks', 'wdsblocks' ),
+				'title' => __( 'WDS Blocks', 'wdsblocks' ),
 			),
 		)
 	);


### PR DESCRIPTION
### DESCRIPTION ###
This feature adds the filter to create `wds-blocks` category to the WDS-Blocks Gutenberg Editor without being loaded from the `{theme}/inc/acf-gutenberg.php` file in the `WD_S` theme. This way, the category is available even if used outside the WDS Starter theme.

### SCREENSHOTS ###
![Screen Shot 2020-08-31 at 2 12 57 PM](https://user-images.githubusercontent.com/428624/91752305-29f79500-eb94-11ea-8f45-8e0644efa22b.png)


### OTHER ###
- [ ] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [ ] Does this issue pass linting? (ESLint)

### STEPS TO VERIFY ###
Add a new block and assign the `wds-blocks` category. It should show up under the category.

### DOCUMENTATION ###
Will this pull request require updating the WDS Blocks [wiki](https://github.com/WebDevStudios/wds-blocks/wiki)?
No, don't think so
